### PR TITLE
Update de.po

### DIFF
--- a/po/de.po
+++ b/po/de.po
@@ -3,8 +3,8 @@ msgstr ""
 "Project-Id-Version: simpleweather\n"
 "Report-Msgid-Bugs-To: simpleweather-gnome@proton.me\n"
 "POT-Creation-Date: 2025-06-23 19:40-0500\n"
-"PO-Revision-Date: 2025-06-24 00:49\n"
-"Last-Translator: \n"
+"PO-Revision-Date: 2025-07-04 10:49\n"
+"Last-Translator: Ahmet Ala\n"
 "Language-Team: German\n"
 "Language: de_DE\n"
 "MIME-Version: 1.0\n"
@@ -35,7 +35,7 @@ msgstr "%f°S"
 #: src/location.ts:75
 #, javascript-format
 msgid "%f°E"
-msgstr "%f°E"
+msgstr "%f°O"
 
 #: src/location.ts:75
 #, javascript-format
@@ -58,17 +58,17 @@ msgstr "H: %s"
 #: src/popup.ts:379
 #, javascript-format
 msgid "L: %s"
-msgstr "L: %s"
+msgstr "T: %s"
 
 #: src/popup.ts:400
 #, javascript-format
 msgid "Temp: %s"
-msgstr "Tempo: %s"
+msgstr "Temperatur: %s"
 
 #: src/popup.ts:401
 #, javascript-format
 msgid "Feels Like: %s"
-msgstr "Gefühl: %s"
+msgstr "Gefühlte Temp.: %s"
 
 #: src/popup.ts:402
 #, javascript-format
@@ -78,22 +78,22 @@ msgstr "Wind: %s, %s"
 #: src/popup.ts:406
 #, javascript-format
 msgid "Gusts: %s"
-msgstr "Preise: %s"
+msgstr "Windböen: %s"
 
 #: src/popup.ts:407
 #, javascript-format
 msgid "Humidity: %s"
-msgstr "Luftfeucht: %s"
+msgstr "Luftfeuchtigkeit: %s"
 
 #: src/popup.ts:408
 #, javascript-format
 msgid "Pressure: %s"
-msgstr "Druck: %s"
+msgstr "Luftdruck: %s"
 
 #: src/popup.ts:409
 #, javascript-format
 msgid "UV High: %s"
-msgstr "UV-Hoch: %s"
+msgstr "UV-Index hoch: %s"
 
 #: src/popup.ts:410
 #, javascript-format
@@ -110,7 +110,7 @@ msgstr "GitHub Repository"
 
 #: src/preferences/aboutPage.ts:61
 msgid "SimpleWeather Version"
-msgstr "Einfaches Wetter Version"
+msgstr "SimpleWeather Version"
 
 #: src/preferences/aboutPage.ts:64
 msgid "Unknown"
@@ -119,7 +119,7 @@ msgstr "Unbekannt"
 #: src/preferences/aboutPage.ts:75
 #, javascript-format
 msgid "This extension is a rewrite of the %s project."
-msgstr "Diese Erweiterung ist ein Umschreiben des %s Projekts."
+msgstr "Diese Erweiterung ist ein Neufassung des %s Projekts."
 
 #: src/preferences/editLocation.ts:33
 #, javascript-format
@@ -164,7 +164,7 @@ msgstr "Maßeinheiten konfigurieren"
 
 #: src/preferences/generalPage.ts:48
 msgid "Custom"
-msgstr "Eigene"
+msgstr "Benutzerdefiniert"
 
 #: src/preferences/generalPage.ts:48
 msgid "Metric"
@@ -172,11 +172,11 @@ msgstr "Metrisch"
 
 #: src/preferences/generalPage.ts:48
 msgid "UK"
-msgstr "TN"
+msgstr "UK"
 
 #: src/preferences/generalPage.ts:48
 msgid "US"
-msgstr "MN"
+msgstr "US"
 
 #: src/preferences/generalPage.ts:61
 msgid "Fahrenheit"
@@ -200,11 +200,11 @@ msgstr "Druck"
 
 #: src/preferences/generalPage.ts:106
 msgid "Rain Measurement"
-msgstr "Regenmessung"
+msgstr "Niederschlagsmessung"
 
 #: src/preferences/generalPage.ts:120
 msgid "Distance"
-msgstr "Distanz"
+msgstr "Entfernung"
 
 #: src/preferences/generalPage.ts:144
 msgid "Degrees"
@@ -212,7 +212,7 @@ msgstr "Grad"
 
 #: src/preferences/generalPage.ts:144
 msgid "Eight-Point Compass"
-msgstr "Acht-Punkte-Kompass"
+msgstr "Acht-Punkte-Kompassrose"
 
 #: src/preferences/generalPage.ts:147
 msgid "Direction"
@@ -224,7 +224,7 @@ msgstr "Wetterdienst"
 
 #: src/preferences/generalPage.ts:160
 msgid "Configure how the weather is attained"
-msgstr "Konfiguriere wie das Wetter erreicht wird"
+msgstr "Konfigurieren, wie Wetterdaten abgerufen werden"
 
 #: src/preferences/generalPage.ts:167
 msgid "Weather Provider"
@@ -232,7 +232,7 @@ msgstr "Wetteranbieter"
 
 #: src/preferences/generalPage.ts:180
 msgid "Configure how your location is found"
-msgstr "Konfigurieren Sie, wie Ihr Standort gefunden wird"
+msgstr "Konfigurieren, wie Ihr Standort gefunden wird"
 
 #: src/preferences/generalPage.ts:184
 msgid "Online"
@@ -256,11 +256,11 @@ msgstr "Aktualisierungsintervall (Minuten)"
 
 #: src/preferences/generalPage.ts:217
 msgid "Accessibility"
-msgstr "Bedienungshilfen"
+msgstr "Barrierefreiheit"
 
 #: src/preferences/generalPage.ts:218
 msgid "Configure accessibility features"
-msgstr "Bedienungshilfen konfigurieren"
+msgstr "Barrierefreiheitsfunktionen konfigurieren"
 
 #: src/preferences/generalPage.ts:221
 msgid "High Contrast"
@@ -268,7 +268,7 @@ msgstr "Hoher Kontrast"
 
 #: src/preferences/generalPage.ts:232
 msgid "Panel"
-msgstr "Platte"
+msgstr "Bedienfeld"
 
 #: src/preferences/generalPage.ts:233
 msgid "Configure the panel and pop-up"
@@ -276,7 +276,7 @@ msgstr "Leiste und Pop-up konfigurieren"
 
 #: src/preferences/generalPage.ts:236
 msgid "Show Sunrise/Sunset"
-msgstr "Sonnenaufgang/Sonnenuntergang anzeigen"
+msgstr "Sonnenauf-/untergang anzeigen"
 
 #: src/preferences/locationsPage.ts:57 src/preferences/locationsPage.ts:80
 msgid "Locations"
@@ -284,7 +284,7 @@ msgstr "Standorte"
 
 #: src/preferences/locationsPage.ts:70
 msgid "Add"
-msgstr "Neu"
+msgstr "Hinzufügen"
 
 #: src/preferences/locationsPage.ts:97
 msgid "Move Up"
@@ -301,7 +301,7 @@ msgstr "Hier hinzufügen"
 #: src/preferences/locationsPage.ts:193
 #, javascript-format
 msgid "Are you sure you want delete %s?"
-msgstr "Sind Sie sicher, dass Sie %s löschen wollen?"
+msgstr "Möchten Sie %s wirklich löschen?"
 
 #: src/preferences/locationsPage.ts:194
 msgid "Cancel"
@@ -326,11 +326,11 @@ msgstr "Etwas anderes hat die Standorte geändert."
 
 #: src/preferences/search.ts:45
 msgid "Search Location"
-msgstr "Suchort"
+msgstr "Standort suchen"
 
 #: src/preferences/search.ts:54
 msgid "City, Neighborhood, etc."
-msgstr "Stadt, Nachbarschaft, etc."
+msgstr "Stadt, Stadtteil, etc."
 
 #: src/preferences/search.ts:59
 msgid "Search"
@@ -346,16 +346,16 @@ msgstr "Keine Ergebnisse."
 
 #: src/preferences/search.ts:187
 msgid "No copyright information available."
-msgstr "Keine Copyright-Informationen verfügbar."
+msgstr "Keine Urheberrechtsinformationen verfügbar."
 
 #: src/prefs.ts:60
 #, javascript-format
 msgid "SimpleWeather doesn't know how to handle your locale.\n"
 "\tError - %s\n"
 "Please consider submitting a bug report on GitHub."
-msgstr "SimpleWeather weiß nicht, wie Sie mit Ihrer Sprache umgehen sollen.\n"
+msgstr "SimpleWeather kann Ihr Gebietsschema nicht verarbeiten.\n"
 "\tFehler - %s\n"
-"Bitte überlegen Sie einen Fehlerbericht auf GitHub einzureichen."
+"Bitte erwägen Sie, einen Fehlerbericht auf GitHub einzureichen."
 
 #: src/prefs.ts:63
 msgid "Don't Show Again"
@@ -367,7 +367,7 @@ msgstr "Ignorieren"
 
 #: src/prefs.ts:63
 msgid "Open GitHub"
-msgstr "Open GitHub"
+msgstr "GitHub öffnen"
 
 #: src/welcome.ts:53
 #, javascript-format
@@ -380,10 +380,10 @@ msgid "%s occasionally connects to the selected weather service. By default, it 
 "  •  %s, an %s service for weather\n"
 "  •  %s, optional for resolving the current location\n"
 "  •  %s, for searching locations by name\n\n"
-msgstr "%s verbindet sich gelegentlich mit dem ausgewählten Wetterdienst. Standardmäßig wird es das Internet nutzen, um sich zu verbinden:\n"
-"  •  %s, ein %s Service für das Wetter\n"
-"  •  %s, optional für die Lösung des aktuellen Standortes\n"
-"  •  %s, für die Suche nach Orten mit dem Namen\n\n"
+msgstr "%s verbindet sich gelegentlich mit dem ausgewählten Wetterdienst. Standardmäßig wird die Internetverbindung genutzt, um sich mit folgenden Diensten zu verbinden:\n"
+"  •  %s, einem %s Dienst für das Wetter\n"
+"  •  %s, optional zur Ermittlung des aktuellen Standorts\n"
+"  •  %s, zur Suche nach Orten per Namen\n\n"
 
 #: src/welcome.ts:83
 #, javascript-format


### PR DESCRIPTION
The previous German translations were often too literal from English. In general I can explain in three points(should generalize to other translations as well)

1) Unnatural phrasing (e.g., "Gefühl" for "Feels Like," "Preise" for "Gusts").

2) Using general words where specific meteorological or UI terms were needed (e.g., "Druck" instead of "Luftdruck," "Bedienungshilfen" instead of "Barrierefreiheit").

3) Failing to use standard German abbreviations (e.g., "O" for East).