### PR TITLE
Fix cardinal points not being translated with gettext (fixes #22)

### DIFF
--- a/src/units.ts
+++ b/src/units.ts
@@ -131,7 +131,7 @@ export class Direction implements Displayable {
                 // While it's not possible to be exactly 8 (second N),
                 // We could round up to 8 since 7.9 and others are valid inputs
                 const map = [ "N", "NE", "E", "SE", "S", "SW", "W", "NW", "N" ];
-                return map[point];
+                return _g(map[point]);
             default:
                 throw new UnitError("Direction unit invalid.");
         }


### PR DESCRIPTION
I fixed the cardinal points not being translated in `units.ts` line 133. The string wasn't picked up by xgettext.