### PR TITLE
transl(de): Update

### DIFF
--- a/po/de.po
+++ b/po/de.po
@@ -4,7 +4,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: simpleweather-gnome@proton.me\n"
 "POT-Creation-Date: 2025-07-23 16:59-0500\n"
 "PO-Revision-Date: 2025-07-23 22:06\n"
-"Last-Translator: \n"
+"Last-Translator: alaahmet\n"
 "Language-Team: German\n"
 "Language: de_DE\n"
 "MIME-Version: 1.0\n"
@@ -44,7 +44,7 @@ msgstr "Feuchtigkeit"
 
 #: src/details.ts:64
 msgid "Gusts"
-msgstr "Bögen"
+msgstr "Böen"
 
 #: src/details.ts:65
 msgid "UV High"
@@ -68,7 +68,7 @@ msgstr "Sonnenuntergang"
 
 #: src/details.ts:70
 msgid "Cloud Cover"
-msgstr "Cloud-Cover"
+msgstr "Wolkenbedeckung"
 
 #: src/details.ts:75 src/popup.ts:409
 msgid "Invalid"
@@ -158,7 +158,7 @@ msgstr "Unterstütze mich"
 
 #: src/preferences/aboutPage.ts:68
 msgid "SimpleWeather Version"
-msgstr "Einfaches Wetter Version"
+msgstr "SimpleWeather Version"
 
 #: src/preferences/aboutPage.ts:71
 msgid "Unknown"
@@ -180,7 +180,7 @@ msgstr "Beiträge und Übersetzungen sind willkommen! Lesen Sie %s."
 #: src/preferences/aboutPage.ts:119
 #, javascript-format
 msgid "If you like this extension, consider starring it on %s."
-msgstr "Wenn dir diese Erweiterung gefällt, solltest du sie auf %s starten."
+msgstr "Wenn Ihnen diese Erweiterung gefällt, geben Sie ihr bitte einen Stern auf %s."
 
 #: src/preferences/aboutPage.ts:122
 msgid "here"
@@ -209,7 +209,7 @@ msgstr "Ziehen und Ablegen von unten, um das Pop-up zu konfigurieren"
 
 #: src/preferences/detailsPage.ts:173 src/preferences/generalPage.ts:235
 msgid "Panel"
-msgstr "Bedienfeld"
+msgstr "Panel"
 
 #: src/preferences/detailsPage.ts:176
 msgid "None"
@@ -282,11 +282,11 @@ msgstr "Metrisch"
 
 #: src/preferences/generalPage.ts:48
 msgid "UK"
-msgstr "TN"
+msgstr "UK"
 
 #: src/preferences/generalPage.ts:48
 msgid "US"
-msgstr "MN"
+msgstr "US"
 
 #: src/preferences/generalPage.ts:61
 msgid "Fahrenheit"
@@ -378,7 +378,7 @@ msgstr "Hell"
 
 #: src/preferences/generalPage.ts:247
 msgid "Afterdark"
-msgstr "Nachdunkle"
+msgstr "Dunkel"
 
 #: src/preferences/generalPage.ts:248
 msgid "Immersive"
@@ -406,7 +406,7 @@ msgstr "Seite des Panels"
 
 #: src/preferences/generalPage.ts:274
 msgid "Order in Panel"
-msgstr "Bestellung im Panel"
+msgstr "Reihenfolge im Panel"
 
 #: src/preferences/locationsPage.ts:57 src/preferences/locationsPage.ts:80
 msgid "Locations"
@@ -501,27 +501,27 @@ msgstr "GitHub öffnen"
 
 #: src/weather.ts:103
 msgid "Clear"
-msgstr "Leeren"
+msgstr "Klar"
 
 #: src/weather.ts:103
 msgid "Sunny"
-msgstr "Sunny"
+msgstr "Sonnig"
 
 #: src/weather.ts:105
 msgid "Cloudy"
-msgstr "bewölkt"
+msgstr "Bewölkt"
 
 #: src/weather.ts:107
 msgid "Rainy"
-msgstr "Rainy"
+msgstr "Regen"
 
 #: src/weather.ts:109
 msgid "Snowy"
-msgstr "Snowy"
+msgstr "Schnee"
 
 #: src/weather.ts:111
 msgid "Stormy"
-msgstr "Stormy"
+msgstr "Sturm"
 
 #: src/weather.ts:113
 msgid "Windy"


### PR DESCRIPTION
fixed some translations.
some were pretty funny. for example 'Clear' was translated as 'Leeren' which means 'to empty'. I changed it to 'Klar'.