### PR TITLE
Fix cardinal points strings not being picked up by xgettext (revision of PR #23)

### DIFF
--- a/src/units.ts
+++ b/src/units.ts
@@ -130,8 +130,8 @@ export class Direction implements Displayable {
                 const point = Math.round(this.#degrees / (360 / 8));
                 // While it's not possible to be exactly 8 (second N),
                 // We could round up to 8 since 7.9 and others are valid inputs
-                const map = [ "N", "NE", "E", "SE", "S", "SW", "W", "NW", "N" ];
-                return _g(map[point]);
+                const map = [ _g("N"), _g("NE"), _g("E"), _g("SE"), _g("S"), _g("SW"), _g("W"), _g("NW"), _g("N") ];
+                return map[point];
             default:
                 throw new UnitError("Direction unit invalid.");
         }


### PR DESCRIPTION
I have recently submitted PR #23 to fix some missing translations, but actually made a mistake. The strings are translated in both cases, when already in the PO files, but xgettext doesn't pick them up if they are passed to gettext through variables or as function outputs. This leads to the generation of an incomplete POT file. By labelling each string separately, this PR should fix the problem.