### PR TITLE
Add rule to Makefile that updates PO files with new strings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ else
 	INSTALLBASE = $(SHARE_PREFIX)/gnome-shell/extensions
 endif
 
-.PHONY: out pack install clean copyicons ts
+.PHONY: out pack install clean copyicons ts update-po
 
 out: $(POT) ts $(SCHEMAOUT) $(SCHEMACP) $(STATICOUT) $(ICONSOUT) $(MOS) $(CSSOUT)
 
@@ -130,3 +130,18 @@ $(ZIP): out
 	printf -- 'NEEDED: zip\n'
 	mkdir -p $(DIST)
 	(cd $(BUILD) && zip ../../$(ZIP) -9r ./)
+	
+# Updates all existing po files by merging them with the pot.
+# If already present, the pot is removed and recreated.
+update-po:
+	rm -f $(POT); \
+	$(MAKE) pot
+	@printf -- 'NEEDED: gettext\n'
+	@if [ -n "$$(ls -A $(PO)/*.po 2>/dev/null)" ]; then \
+		for f in $(POFILES); do \
+			printf -- 'Merging %s with $(POT) ' "$$f"; \
+			msgmerge --no-fuzzy-matching --update --backup=none $$f $(POT); \
+		done; \
+	else \
+		printf -- 'Unsuccessful PO update: there are no PO files\n'; \
+	fi


### PR DESCRIPTION
With this PR I'm proposing to add a rule to the Makefile called "update-po" which forces the update of the POT file (template for string translations) and merges it with the PO files in order to add to them newly found strings from the sources. The merge takes place only if at least one PO file is present and it keeps already translated strings. I chose to disable fuzzy matching because the automatic translations could be incorrect and if the PO files aren't reviewed by any translator before building, the UI could show wrong and misleading text instead of just untranslated English.

If this rule is added, the translators, after having synchronised their repo, will be using the command `make update-po` to have new strings added to the PO files.