### PR TITLE
Enhance settings of popup menu position

### DIFF
--- a/schemas/org.gnome.shell.extensions.simple-weather.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.simple-weather.gschema.xml
@@ -160,6 +160,12 @@
             <summary>Priority of button in panel box</summary>
         </key>
 
+        <key name="panel-offset" type="d">
+            <default>0.0</default>
+            <summary>Panel Offset</summary>
+            <description>Offset of popup menu relative to panel button (0 to 100)</description>
+        </key>
+
         <key name="panel-detail" type="s">
             <default>'temp'</default>
             <summary>Detail to show in the panel</summary>

--- a/src/config.ts
+++ b/src/config.ts
@@ -358,6 +358,17 @@ export class Config {
         this.#handlerIds.push(id);
     }
 
+    getPanelOffset() : number {
+        return this.#settings.get_double("panel-offset") / 100;
+    }
+
+    onPanelOffsetChanged(callback : () => void) : void {
+        const id = this.#settings.connect("changed", (_, key) => {
+            if(key === "panel-offset") callback();
+        });
+        this.#handlerIds.push(id);
+    }
+
     getPanelDetail() : Details | null {
         const detail = this.#settings.get_string("panel-detail");
         if(!Object.values(Details).includes(detail as Details)) return null;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -146,7 +146,8 @@ export default class SimpleWeatherExtension extends Extension {
     }
 
     #createIndicator() : PanelMenu.Button {
-        const indic = new PanelMenu.Button(0, "Weather", false);
+        const menuOffset = this.#config!.getPanelOffset();
+        const indic = new PanelMenu.Button(menuOffset, "Weather", false);
         this.#popup = new Popup({
             config: this.#config!,
             metadata: this.metadata,
@@ -256,6 +257,7 @@ export default class SimpleWeatherExtension extends Extension {
         this.#config!.onSecondaryPanelDetailChanged(this.#rebuildIndicator.bind(this));
         this.#config!.onShowPanelIconChanged(this.#rebuildIndicator.bind(this));
         this.#config!.onPanelPositionChanged(this.#rebuildIndicator.bind(this));
+        this.#config!.onPanelOffsetChanged(this.#rebuildIndicator.bind(this));
         this.#config!.onThemeChanged(this.#rebuildIndicator.bind(this));
         this.#config!.onHighContrastChanged(this.#rebuildIndicator.bind(this));
 

--- a/src/preferences/generalPage.ts
+++ b/src/preferences/generalPage.ts
@@ -271,6 +271,9 @@ export class GeneralPage extends Adw.PreferencesPage {
         });
         panelBoxRow.connect("notify::selected", () => {
             settings.set_enum("panel-box", panelBoxRow.selected);
+            // Auto-adjust panel offset based on panel position
+            const offsetValues = [0, 50, 100];
+            settings.set_double("panel-offset", offsetValues[panelBoxRow.selected]);
             settings.apply();
         });
         panelGroup.add(panelBoxRow);
@@ -290,6 +293,28 @@ export class GeneralPage extends Adw.PreferencesPage {
             settings.apply();
         });
         panelGroup.add(panelPriorityRow);
+        const panelOffsetRow = new Adw.SpinRow({
+            title: _g("Panel Offset"),
+            adjustment: new Gtk.Adjustment({
+                lower: 0.0,
+                upper: 100.0,
+                step_increment: 5.0,
+                page_increment: 10.0,
+                value: settings.get_double("panel-offset")
+            }),
+            digits: 0
+        });
+        panelOffsetRow.connect("notify::value", () => {
+            settings.set_double("panel-offset", panelOffsetRow.value);
+            settings.apply();
+        });
+        // Update UI when offset is changed by panel position setting
+        settings.connect("changed", (_, key) => {
+            if(key === "panel-offset") {
+                panelOffsetRow.value = settings.get_double("panel-offset");
+            }
+        });
+        panelGroup.add(panelOffsetRow);
         const useSymbolicRow = new Adw.SwitchRow({
             title: _g("Use Symbolic Icons in Panel"),
             active: settings.get_boolean("symbolic-icons-panel")


### PR DESCRIPTION
As this issue [Centre popup window when button is at centre #10](https://github.com/romanlefler/SimpleWeather/issues/10) pointed out. It's desirable to have the popup menu at centre when the panel button is set to "centre".

This PR adjusts the default offset of left-sided and centre-sided popup menu relatively to the panel button.
<img width="796" height="370" alt="image" src="https://github.com/user-attachments/assets/8aab9407-6e1e-482e-bb23-a2c97907c12c" />
<img width="844" height="425" alt="image" src="https://github.com/user-attachments/assets/90537e6b-3ff2-4888-81ef-5cb7e5e020cb" />

Also adds a "Panel Offset" preference for Dash to Dock users to customize the offset so that the popup menu won't cover the dock (if wanted).

