### PR TITLE
About: Pretty-print (wrap) JSON settings dump

### DIFF
--- a/src/preferences/aboutPage.ts
+++ b/src/preferences/aboutPage.ts
@@ -110,7 +110,7 @@ export class AboutPage extends Adw.PreferencesPage {
             obj["gnome-version"] = PACKAGE_VERSION;
             obj["user-locale"] = (getLocales() ?? [])[0] ?? "Unknown";
             settingsBtnContent.icon_name = "checkbox";
-            settingsButton.get_clipboard().set(JSON.stringify(obj));
+            settingsButton.get_clipboard().set(JSON.stringify(obj, null, 1));
 
             let toast = new Adw.Toast({
                 title: _g("Copied settings JSON to clipboard.")


### PR DESCRIPTION
Use the three-argument form of `JSON.stringify()` to dump the settings object line-wrapped and with 1-space indents, for readability when pasted into bug reports (or anywhere else).

For example, in [my recently-opened issue](https://github.com/romanlefler/SimpleWeather/issues/95), instead of this:


> ## Settings
> ```json
> {"details-list":"['conditionText', 'windSpeedAndDir', 'sunrise', 'humidity', 'feelsLike', 'gusts', 'sunset', 'precipitation']","theme":"''","show-suntime":"false","secondary-panel-detail":"''","is-activated":"true","panel-priority":"0","panel-box":"'center'","panel-offset":"20.0","main-location-index":"0","my-loc-provider":"'disable'","unit-preset":"'us'","app-version":"49.2.0","gnome-version":"49.2","user-locale":"en-US"}
> ```
> 

the pasted dump would look like this:

> ## Settings
> ```json
> {
>  "details-list": "['conditionText', 'windSpeedAndDir', 'sunrise', 'humidity', 'feelsLike', 'gusts', 'sunset', 'precipitation']",
>  "theme": "''",
>  "show-suntime": "false",
>  "secondary-panel-detail": "''",
>  "is-activated": "true",
>  "panel-priority": "0",
>  "panel-box": "'center'",
>  "panel-offset": "20.0",
>  "main-location-index": "0",
>  "my-loc-provider": "'disable'",
>  "unit-preset": "'us'",
>  "app-version": "49.2.0",
>  "gnome-version": "49.2",
>  "user-locale": "en-US"
> }
> ```

(I don't love that the entire `details-list` is still dumped onto a single line, but that's a consequence of the `Record<string, string>` type of the temporary object, and the value of `details-list` (an `(as)`-format `GVariant`) having already been dumped to string form using `GVariant::print()`.)