### PR TITLE
feat(providers): Add QWeather weather provider, ip.sb location provider and QWeather GeoAPI city search

### DIFF
--- a/schemas/org.gnome.shell.extensions.simple-weather.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.simple-weather.gschema.xml
@@ -9,10 +9,12 @@
         <value value="2" nick="geoclue" />
         <value value="3" nick="disable" />
         <value value="4" nick="ipapi.co" />
+        <value value="5" nick="ip.sb" />
     </enum>
     <enum id="org.gnome.shell.extensions.simple-weather.weather-provider">
         <value value="1" nick="open-meteo" />
         <value value="2" nick="openweathermap" />
+        <value value="3" nick="qweather" />
     </enum>
     <enum id="org.gnome.shell.extensions.simple-weather.unit-preset">
         <value value="0" nick="custom" />
@@ -230,6 +232,11 @@
         <key name="api-keys" type="a{ss}">
             <default>{ }</default>
             <summary>API Keys</summary>
+        </key>
+
+        <key name="api-hosts" type="a{ss}">
+            <default>{ }</default>
+            <summary>API Hosts</summary>
         </key>
 
     </schema>

--- a/src/config.ts
+++ b/src/config.ts
@@ -159,7 +159,7 @@ export class Config {
 
     getMyLocationProvider() : MyLocationProvider {
         const val = this.#settings.get_enum("my-loc-provider");
-        if(val > 2 || val < 1) return 1;
+        if(val > 5 || val < 1) return 1;
         else return val;
     }
 
@@ -515,6 +515,22 @@ export class Config {
     onApiKeysChanged(callback : () => void) : void {
         const id = this.#settings.connect("changed", (_, key) => {
             if(key === "api-keys") callback();
+        });
+        this.#addId(id);
+    }
+
+    /**
+     * Gets the API hosts map. The key is the name of the provider and the value is the API host.
+     * The map will not be NULL or undefined, but each provider is not guaranteed to be present.
+     */
+    getApiHosts() : Map<string, string> {
+        const gval = this.#settings.get_value("api-hosts");
+        return readGTypeABSS(gval);
+    }
+
+    onApiHostsChanged(callback : () => void) : void {
+        const id = this.#settings.connect("changed", (_, key) => {
+            if(key === "api-hosts") callback();
         });
         this.#addId(id);
     }

--- a/src/libsoup.ts
+++ b/src/libsoup.ts
@@ -48,7 +48,7 @@ export class LibSoup {
     }
 
     async fetchJson(url : string, params : Record<string, string>,
-        useTrackedAgent = false) : Promise<ServerResponse> {
+        useTrackedAgent = false, headers? : Record<string, string>) : Promise<ServerResponse> {
 
         const sess = useTrackedAgent ? this.#realUserSession : this.#genericSession;
         if(!sess) throw new Error("Attempt to use LibSoup after freed.");
@@ -56,6 +56,11 @@ export class LibSoup {
         const paramsEncoded = Soup.form_encode_hash(params);
         const msg = Soup.Message.new_from_encoded_form("GET", url, paramsEncoded);
         msg.request_headers.append("Accept", "application/json");
+        if(headers) {
+            for(const [ k, v ] of Object.entries(headers)) {
+                msg.request_headers.append(k, v);
+            }
+        }
 
         return new Promise((resolve, reject) => {
             sess.send_and_read_async(

--- a/src/myLocation.ts
+++ b/src/myLocation.ts
@@ -34,7 +34,8 @@ export enum MyLocationProvider {
     IpInfoIo = 1,
     Geoclue = 2,
     Disable = 3,
-    Ipapi = 4
+    Ipapi = 4,
+    IpSb = 5
 }
 
 export interface MyLocResult extends LatLon {
@@ -85,6 +86,9 @@ export async function getMyLocation() : Promise<MyLocResult> {
                 case MyLocationProvider.Ipapi:
                     isGettingLoc = ipapiGetLoc();
                     break;
+                case MyLocationProvider.IpSb:
+                    isGettingLoc = ipsbGetLoc();
+                    break;
                 case MyLocationProvider.Disable:
                     throw new Error("My Location Disabled");
             }
@@ -122,6 +126,19 @@ async function ipinfoGetLoc() : Promise<MyLocResult> {
 
 async function ipapiGetLoc() : Promise<MyLocResult> {
     const resp = await soup.fetchJson("https://ipapi.co/json", { });
+    const body = resp.body;
+    return {
+        lat: body.latitude,
+        lon: body.longitude,
+        city: body.city ?? null,
+        country: body.country_code ?? null
+    };
+}
+
+async function ipsbGetLoc() : Promise<MyLocResult> {
+    const resp = await soup.fetchJson("https://api.ip.sb/geoip", { });
+    if(!resp.is2xx) throw new Error(`ip.sb responded with error ${resp.status}.`);
+
     const body = resp.body;
     return {
         lat: body.latitude,

--- a/src/preferences/generalPage.ts
+++ b/src/preferences/generalPage.ts
@@ -20,7 +20,7 @@ import Gtk from "gi://Gtk";
 import Gio from "gi://Gio";
 import Adw from "gi://Adw";
 import { gettext as _g } from "resource:///org/gnome/Shell/Extensions/js/extensions/prefs.js";
-import { WeatherProviderKeys, provRequiresKey } from "../providers/provider.js";
+import { WeatherProviderKeys, provRequiresKey, provRequiresHost } from "../providers/provider.js";
 import { readGTypeABSS, writeGTypeABSS } from "../config.js";
 import { LibSoup } from "../libsoup.js";
 import { isNoInternet } from "../utils.js";
@@ -190,6 +190,11 @@ export class GeneralPage extends Adw.PreferencesPage {
             apiKeyRow.title = keyNeeded ? _g("API Key (Required)") : _g("API Key");
             apiKeyRow.sensitive = keyNeeded;
             apiKeyRow.text = this.#getApiKey(settings, i);
+
+            const hostNeeded = provRequiresHost(i);
+            apiHostRow.title = hostNeeded ? _g("API Host (Required)") : _g("API Host");
+            apiHostRow.sensitive = hostNeeded;
+            apiHostRow.text = this.#getApiHost(settings, i);
         });
         weatherServiceGroup.add(wProvRow);
 
@@ -205,6 +210,18 @@ export class GeneralPage extends Adw.PreferencesPage {
         apiKeyRow.connect("apply", setKey);
         weatherServiceGroup.add(apiKeyRow);
 
+        const currentHostNeeded = provRequiresHost(currentWProv);
+        const currentApiHost = this.#getApiHost(settings, currentWProv);
+        const apiHostRow = new Adw.EntryRow({
+            title: currentHostNeeded ? _g("API Host (Required)") : _g("API Host"),
+            sensitive: currentHostNeeded,
+            text: currentApiHost,
+            showApplyButton: true
+        });
+        const setHost = () => this.#setApiHost(settings, apiHostRow, wProvRow);
+        apiHostRow.connect("apply", setHost);
+        weatherServiceGroup.add(apiHostRow);
+
         this.add(weatherServiceGroup);
 
         const myLocGroup = new Adw.PreferencesGroup({
@@ -215,16 +232,17 @@ export class GeneralPage extends Adw.PreferencesPage {
         const myLocProvs = new Gtk.StringList();
         myLocProvs.append(`${_g("Online")} - ipapi.co`);
         myLocProvs.append(`${_g("Online")} - IPinfo`);
+        myLocProvs.append(`${_g("Online")} - ip.sb`);
         myLocProvs.append(`${_g("System")} - Geoclue`);
         myLocProvs.append(_g("Disable"));
-        const myLocProvFromEnum = [ 0x0, 1, 2, 3, 0 ];
+        const myLocProvFromEnum = [ 0x0, 1, 3, 4, 0, 2 ];
         const myLocRow = new Adw.ComboRow({
             title: _g("Provider"),
             model: myLocProvs,
             selected: myLocProvFromEnum[settings.get_enum("my-loc-provider")]
         });
         myLocRow.connect("notify::selected", () => {
-            const myLocProvToEnum = [ 4, 1, 2, 3 ];
+            const myLocProvToEnum = [ 4, 1, 5, 2, 3 ];
             settings.set_enum("my-loc-provider", myLocProvToEnum[myLocRow.selected]);
             settings.apply();
         });
@@ -395,6 +413,12 @@ export class GeneralPage extends Adw.PreferencesPage {
         return map.get(key) ?? "";
     }
 
+    #getApiHost(settings : Gio.Settings, providerIndex : number) : string {
+        const map = readGTypeABSS(settings.get_value("api-hosts"));
+        const key = WeatherProviderKeys[providerIndex];
+        return map.get(key) ?? "";
+    }
+
     #setApiKey(settings : Gio.Settings, apiKeyRow : Adw.EntryRow, wProvRow : Adw.ComboRow) {
         const v = apiKeyRow.text.trim();
         const i = wProvRow.selected;
@@ -408,6 +432,10 @@ export class GeneralPage extends Adw.PreferencesPage {
         settings.set_value("api-keys", gtype);
         settings.apply();
 
+        // Only OpenWeatherMap supports online key validation.
+        // Don't validate keys of other providers against its API
+        if(k !== "OpenWeatherMap") return;
+
         this.#validateOwmKey(v).then(msg => {
             if(msg !== null) {
                 const alert = new Gtk.AlertDialog({
@@ -417,6 +445,20 @@ export class GeneralPage extends Adw.PreferencesPage {
                 alert.show(this.#window);
             }
         });
+    }
+
+    #setApiHost(settings : Gio.Settings, apiHostRow : Adw.EntryRow, wProvRow : Adw.ComboRow) {
+        const v = apiHostRow.text.trim();
+        const i = wProvRow.selected;
+        const k = WeatherProviderKeys[i];
+
+        const map = readGTypeABSS(settings.get_value("api-hosts"));
+        if(v.length > 0) map.set(k, v);
+        else map.delete(k);
+
+        const gtype = writeGTypeABSS(map);
+        settings.set_value("api-hosts", gtype);
+        settings.apply();
     }
 
     /**

--- a/src/preferences/search.ts
+++ b/src/preferences/search.ts
@@ -31,6 +31,11 @@ import { OmModel } from "../openmeteo-models.js";
 const SEARCH_BASE = "https://nominatim.openstreetmap.org";
 const SEARCH_ENDPOINT = `${SEARCH_BASE}/search`;
 
+// The enum value of the QWeather weather provider
+const QWEATHER_PROVIDER = 3;
+// Must match the nameKey of the QWeather provider
+const QWEATHER_KEY = "QWeather";
+
 interface SelLoc {
     // What to show on the button to clarify results
     buttonName : string;
@@ -114,7 +119,7 @@ export async function searchDialog(parent : Gtk.Window, soup : LibSoup, cfg : Co
                 soup,
                 currentLocNames: cfg.getLocations().map(l => l.getName())
             };
-            fetchNominatim(a).then(locArr => {
+            getSearchFetcher(cfg)(a).then(locArr => {
                 const oldLen = resultsLocList.length;
                 resultsLocList.splice(0, oldLen, ...locArr);
                 populateList(stringList, locArr);
@@ -157,6 +162,20 @@ interface SearchArgs {
     resultsList : Gtk.StringList;
     soup : LibSoup;
     currentLocNames : string[];
+}
+
+/**
+ * Uses the QWeather GeoAPI for searching when QWeather is selected
+ * and configured as the weather provider (Nominatim/OpenStreetMap
+ * doesn't work well in some regions), otherwise uses Nominatim.
+ */
+function getSearchFetcher(cfg : Config) : (a : SearchArgs) => Promise<SelLoc[]> {
+    if(cfg.getWeatherProvider() === QWEATHER_PROVIDER) {
+        const host = cfg.getApiHosts().get(QWEATHER_KEY);
+        const key = cfg.getApiKeys().get(QWEATHER_KEY);
+        if(host && key) return a => fetchQweather(a, host, key);
+    }
+    return fetchNominatim;
 }
 
 function showNoInternetDialog(parent : Gtk.Window) {
@@ -234,6 +253,56 @@ async function fetchNominatim(a : SearchArgs) : Promise<SelLoc[]> {
             lat,
             lon,
             countryCode: place.address?.country_code
+        });
+    }
+    return list;
+}
+
+async function fetchQweather(a : SearchArgs, hostIn : string, key : string) : Promise<SelLoc[]> {
+    // Strip the scheme and trailing slashes in case the user included them
+    const host = hostIn.replace(/^https?:\/\//, "").replace(/\/+$/, "");
+    const params = {
+        location: a.search,
+        number: "10"
+    };
+    const resp = await a.soup.fetchJson(
+        `https://${host}/geo/v2/city/lookup`, params, false,
+        { "X-QW-Api-Key": key }
+    );
+    if(!resp.is2xx) throw new Error(`QWeather status code ${resp.status}.`);
+    const b = resp.body;
+    if(b.code !== "200") throw new Error(`QWeather gave error code ${b.code}.`);
+
+    const locs : any[] = b.location ?? [ ];
+    if(!locs[0]) {
+        a.licenseLabel.label = _g("No results.");
+        return [ ];
+    }
+
+    const refer = b.refer;
+    const licenseParts : string[] = [ ...refer?.license ?? [ ], ...refer?.sources ?? [ ] ];
+    a.licenseLabel.label = licenseParts.length > 0
+        ? licenseParts.join(", ")
+        : _g("No copyright information available.");
+
+    const list : SelLoc[] = [ ];
+    for(let loc of locs) {
+        // e.g. "Dongcheng, Beijing City, China"
+        const display = [ loc.name, loc.adm1, loc.country ]
+            .filter((s : any) => typeof s === "string" && s.length > 0)
+            .join(", ");
+
+        let friendlyName = loc.name;
+        // If a duplicate name exists use the longer one
+        if(a.currentLocNames.includes(friendlyName)) friendlyName = display;
+
+        list.push({
+            buttonName: display,
+            friendlyName,
+            lat: parseFloat(loc.lat),
+            lon: parseFloat(loc.lon),
+            // QWeather does not return a country code
+            countryCode: undefined
         });
     }
     return list;

--- a/src/providers/provider.ts
+++ b/src/providers/provider.ts
@@ -20,6 +20,7 @@ import { LibSoup } from "../libsoup.js";
 import { Weather } from "../weather.js";
 import { OpenMeteo } from "./openmeteo.js";
 import { OpenWeatherMap } from "./openweathermap.js";
+import { QWeather } from "./qweather.js";
 
 export interface Provider {
 
@@ -36,19 +37,33 @@ export function createProvider(soup : LibSoup, config : Config) {
             return new OpenMeteo(soup, config);
         case 2:
             return new OpenWeatherMap(soup, config);
+        case 3:
+            return new QWeather(soup, config);
         default:
             throw new Error("Invalid weather provider ID.");
     }
 }
 
 export const WeatherProviderKeys : readonly string[] = Object.freeze([
-    "Open-Meteo", "OpenWeatherMap"
+    "Open-Meteo", "OpenWeatherMap", "QWeather"
 ]);
 
 export function provRequiresKey(index : number) : boolean {
     const v : Record<string, boolean> = {
         0: false,
-        1: true
+        1: true,
+        2: true
+    };
+    const ret = v[index];
+    if(typeof ret !== "boolean") throw new Error("Invalid argument.");
+    return ret;
+}
+
+export function provRequiresHost(index : number) : boolean {
+    const v : Record<string, boolean> = {
+        0: false,
+        1: false,
+        2: true
     };
     const ret = v[index];
     if(typeof ret !== "boolean") throw new Error("Invalid argument.");

--- a/src/providers/qweather.ts
+++ b/src/providers/qweather.ts
@@ -1,0 +1,297 @@
+/*
+    Copyright 2026 Roman Lefler
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+import { Config } from "../config.js";
+import { LibSoup } from "../libsoup.js";
+import { Direction, Percentage, Pressure, RainMeasurement, Speed, SpeedAndDir, Temp, Countdown } from "../units.js";
+import { Condition, Forecast, Weather, gettextCondit } from "../weather.js";
+import { getGIconName, Icons } from "../icons.js"
+import { Provider } from "./provider.js";
+import { Location } from "../location.js";
+
+export class QWeather implements Provider {
+
+    readonly #soup : LibSoup;
+    readonly #config : Config;
+
+    readonly nameKey = "QWeather";
+
+    constructor(soup : LibSoup, config : Config) {
+        this.#soup = soup;
+        this.#config = config;
+    }
+
+    /**
+     * Gets the user-defined API host and API key,
+     * throwing if either one is not set.
+     */
+    #getAuth() : { host : string, headers : Record<string, string> } {
+        const key = this.#config.getApiKeys().get(this.nameKey) ?? "";
+        if(key.length === 0) throw new Error("QWeather API key is not set.");
+
+        let host = this.#config.getApiHosts().get(this.nameKey) ?? "";
+        // Strip the scheme and trailing slashes in case the user included them
+        host = host.replace(/^https?:\/\//, "").replace(/\/+$/, "");
+        if(host.length === 0) throw new Error("QWeather API host is not set.");
+
+        return {
+            host,
+            headers: { "X-QW-Api-Key": key }
+        };
+    }
+
+    async #fetch(path : string, params : Record<string, string>) : Promise<any> {
+        const { host, headers } = this.#getAuth();
+
+        const response = await this.#soup.fetchJson(
+            `https://${host}${path}`, params, false, headers
+        );
+        if(!response.is2xx) {
+            throw new Error(
+                `QWeather gave status code ${response.status}. ` +
+                `Reason: ${response.body?.reason ?? response.body?.code ?? "None Given"}`
+            );
+        }
+
+        const body = response.body;
+        // Some errors are returned with HTTP 200 and an error code in the body
+        if(body?.code !== undefined && body.code !== "200") {
+            throw new Error(
+                `QWeather gave error code ${body.code}. ` +
+                `Reason: ${body.reason ?? "None Given"}`
+            );
+        }
+
+        return body;
+    }
+
+    async fetchWeather() : Promise<Weather> {
+        const loc = this.#config.getMainLocation();
+        const coords = await loc.latLon();
+        // The API supports at most two decimal places
+        const lat = coords.lat.toFixed(2);
+        const lon = coords.lon.toFixed(2);
+
+        const [ cur, daily, hourly ] = await Promise.all([
+            this.#fetch(`/weather/v1/current/${lat}/${lon}`, { localTime: "true" }),
+            this.#fetch(`/weather/v1/daily/${lat}/${lon}`, { days: "7", localTime: "true" }),
+            this.#fetch(`/weather/v1/hourly/${lat}/${lon}`, { hours: "28", localTime: "true" })
+        ]);
+
+        const days = daily.days!;
+        const hours = hourly.hours!;
+
+        const code = parseInt(cur.condition?.code ?? "") || 999;
+        const { c: condit, i: icon } = codeToIcon[code] ?? defaultIcon;
+
+        const temp = new Temp(cToF(cur.temperature.value));
+        const feelsLike = new Temp(cToF(cur.feelsLike.value));
+        const wind = new Speed(mpsToMph(cur.wind?.speed?.value ?? 0));
+        const gusts = new Speed(mpsToMph(cur.windGust?.value ?? 0));
+        const windDir = new Direction(cur.wind?.direction?.degree ?? 0);
+        const humidity = new Percentage((cur.humidity ?? 0) * 100);
+        // hPa to inHg
+        const pressure = new Pressure((cur.pressure?.value ?? 0) * 0.02953);
+        const uvIndex = cur.uvIndex ?? 0;
+        const precipitation = new RainMeasurement(mmToIn(cur.precipitation?.amount?.value ?? 0));
+        const cloudCover = new Percentage((cur.cloudCover ?? 0) * 100);
+
+        const observedAt = isoToDate(cur.forecastTime ?? cur.obsTime);
+
+        // Sunrise/sunset of the current day
+        const todaySunrise = isoToDate(days[0]?.astro?.sunrise);
+        const todaySunset = isoToDate(days[0]?.astro?.sunset);
+        const isNight = observedAt < todaySunrise || observedAt > todaySunset;
+        const gIconName = getGIconName(icon, isNight);
+
+        // If sunrise/sunset have already happened, take the next day's
+        const now = new Date();
+        let sunrise = todaySunrise;
+        if(now > sunrise && days[1]?.astro?.sunrise !== undefined) {
+            sunrise = isoToDate(days[1].astro.sunrise);
+        }
+        let sunset = todaySunset;
+        if(now > sunset && days[1]?.astro?.sunset !== undefined) {
+            sunset = isoToDate(days[1].astro.sunset);
+        }
+
+        const dayForecast : Forecast[] = [ ];
+        const dayCount = days.length;
+        for(let i = 0; i < dayCount; i++) {
+            const daytime = days[i].daytime!;
+            // We always want day icons for day forecast
+            const fCode = parseInt(daytime.condition?.code ?? "") || 999;
+            const fIcon = codeToIcon[fCode] ?? defaultIcon;
+            const fIconName = getGIconName(fIcon.i, false);
+            dayForecast.push({
+                date: isoToDate(days[i].forecastStartTime),
+                gIconName: fIconName,
+                conditionText: gettextCondit(fIcon.c, false),
+                tempMin: new Temp(cToF(days[i].temperatureMin.value)),
+                tempMax: new Temp(cToF(days[i].temperatureMax.value)),
+                precipChancePercent: Math.round((daytime.precipitation?.probability ?? 0) * 100)
+            });
+        }
+
+        const hourForecast : Forecast[] = [ ];
+        const hourCount = Math.min(hours.length, 28);
+        for(let i = 0; i < hourCount; i++) {
+            const fCode = parseInt(hours[i].condition?.code ?? "") || 999;
+            const fIcon = codeToIcon[fCode] ?? defaultIcon;
+            // QWeather uses codes 150-153 for night conditions
+            const fIsNight = nightCode(fCode);
+            const fIconName = getGIconName(fIcon.i, fIsNight);
+            hourForecast.push({
+                date: isoToDate(hours[i].forecastTime),
+                gIconName: fIconName,
+                conditionText: gettextCondit(fIcon.c, fIsNight),
+                temp: new Temp(cToF(hours[i].temperature.value)),
+                precipChancePercent: Math.round((hours[i].precipitation?.probability ?? 0) * 100)
+            });
+        }
+
+        return {
+            condit,
+            temp,
+            gIconName,
+            isNight,
+            observedAt,
+            sunrise,
+            sunset,
+            forecast: dayForecast,
+            hourForecast,
+            feelsLike,
+            wind,
+            gusts,
+            windDir,
+            humidity,
+            pressure,
+            uvIndex,
+            precipitation,
+            cloudCover,
+            conditionText: gettextCondit(condit, isNight),
+            windSpeedAndDir: new SpeedAndDir(wind, windDir),
+            providerName: this.nameKey,
+            loc,
+            sunEventCountdown: new Countdown(sunrise < sunset ? sunrise : sunset)
+        };
+    }
+
+}
+
+function cToF(c : number) : number {
+    return c * 9 / 5 + 32;
+}
+
+function mpsToMph(mps : number) : number {
+    return mps / 0.44704;
+}
+
+function mmToIn(mm : number) : number {
+    return mm * 0.0393701;
+}
+
+function isoToDate(ts : string | undefined, fallback : Date = new Date()) : Date {
+    if(ts === undefined) return new Date(fallback.getTime());
+    return new Date(ts);
+}
+
+function nightCode(code : number) : boolean {
+    return code >= 150 && code <= 153;
+}
+
+// https://dev.qweather.com/docs/resource/icons/
+const codeToIcon : Record<number, { c : Condition, i : string }> = {
+    100: { c : Condition.CLEAR, i: Icons.Clear },
+
+    101: { c : Condition.CLOUDY, i: Icons.Cloudy },
+    102: { c : Condition.CLOUDY, i: Icons.Cloudy },
+    103: { c : Condition.CLOUDY, i: Icons.Cloudy },
+    104: { c : Condition.CLOUDY, i: Icons.Overcast },
+
+    // Night variants of the above
+    150: { c : Condition.CLEAR, i: Icons.Clear },
+    151: { c : Condition.CLOUDY, i: Icons.Cloudy },
+    152: { c : Condition.CLOUDY, i: Icons.Cloudy },
+    153: { c : Condition.CLOUDY, i: Icons.Cloudy },
+
+    300: { c : Condition.RAINY, i: Icons.RainScattered },
+    301: { c : Condition.RAINY, i: Icons.Rainy },
+    302: { c : Condition.STORMY, i: Icons.Stormy },
+    303: { c : Condition.STORMY, i: Icons.Stormy },
+    304: { c : Condition.STORMY, i: Icons.Stormy },
+    305: { c : Condition.RAINY, i: Icons.RainScattered },
+    306: { c : Condition.RAINY, i: Icons.Rainy },
+    307: { c : Condition.RAINY, i: Icons.Rainy },
+    308: { c : Condition.RAINY, i: Icons.Rainy },
+    309: { c : Condition.RAINY, i: Icons.RainScattered },
+    310: { c : Condition.RAINY, i: Icons.Rainy },
+    311: { c : Condition.RAINY, i: Icons.Rainy },
+    312: { c : Condition.RAINY, i: Icons.Rainy },
+    313: { c : Condition.RAINY, i: Icons.FreezingRain },
+    314: { c : Condition.RAINY, i: Icons.RainScattered },
+    315: { c : Condition.RAINY, i: Icons.Rainy },
+    316: { c : Condition.RAINY, i: Icons.Rainy },
+    317: { c : Condition.RAINY, i: Icons.Rainy },
+    318: { c : Condition.RAINY, i: Icons.Rainy },
+    319: { c : Condition.RAINY, i: Icons.Rainy },
+    320: { c : Condition.RAINY, i: Icons.Rainy },
+    321: { c : Condition.STORMY, i: Icons.Stormy },
+    322: { c : Condition.STORMY, i: Icons.Stormy },
+    323: { c : Condition.RAINY, i: Icons.Rainy },
+    324: { c : Condition.RAINY, i: Icons.Rainy },
+    325: { c : Condition.RAINY, i: Icons.Rainy },
+    326: { c : Condition.RAINY, i: Icons.Rainy },
+    327: { c : Condition.RAINY, i: Icons.Rainy },
+    350: { c : Condition.RAINY, i: Icons.RainScattered },
+    351: { c : Condition.RAINY, i: Icons.Rainy },
+    399: { c : Condition.RAINY, i: Icons.Rainy },
+
+    400: { c : Condition.SNOWY, i: Icons.Snowy },
+    401: { c : Condition.SNOWY, i: Icons.Snowy },
+    402: { c : Condition.SNOWY, i: Icons.Snowy },
+    403: { c : Condition.SNOWY, i: Icons.Snowy },
+    404: { c : Condition.SNOWY, i: Icons.FreezingRain },
+    405: { c : Condition.SNOWY, i: Icons.FreezingRain },
+    406: { c : Condition.SNOWY, i: Icons.FreezingRain },
+    407: { c : Condition.SNOWY, i: Icons.Snowy },
+    408: { c : Condition.SNOWY, i: Icons.Snowy },
+    409: { c : Condition.SNOWY, i: Icons.Snowy },
+    410: { c : Condition.SNOWY, i: Icons.Snowy },
+    456: { c : Condition.SNOWY, i: Icons.Snowy },
+    457: { c : Condition.SNOWY, i: Icons.Snowy },
+    499: { c : Condition.SNOWY, i: Icons.Snowy },
+
+    500: { c : Condition.CLOUDY, i: Icons.Foggy },
+    501: { c : Condition.CLOUDY, i: Icons.Foggy },
+    502: { c : Condition.CLOUDY, i: Icons.Foggy },
+    503: { c : Condition.CLOUDY, i: Icons.Foggy },
+    504: { c : Condition.CLOUDY, i: Icons.Foggy },
+    507: { c : Condition.CLOUDY, i: Icons.Foggy },
+    508: { c : Condition.CLOUDY, i: Icons.Foggy },
+    509: { c : Condition.CLOUDY, i: Icons.Foggy },
+    510: { c : Condition.CLOUDY, i: Icons.Foggy },
+    511: { c : Condition.CLOUDY, i: Icons.Foggy },
+    512: { c : Condition.CLOUDY, i: Icons.Foggy },
+    513: { c : Condition.CLOUDY, i: Icons.Foggy },
+    514: { c : Condition.CLOUDY, i: Icons.Foggy },
+    515: { c : Condition.CLOUDY, i: Icons.Foggy },
+
+    900: { c : Condition.CLEAR, i: Icons.Clear },
+    901: { c : Condition.CLEAR, i: Icons.Clear }
+};
+const defaultIcon = { c : Condition.CLOUDY, i: Icons.Cloudy };


### PR DESCRIPTION
Implements the feature requested in #150. Adds providers that work better for users in China, with no refactoring of existing code and no new dependencies.

### New weather provider: QWeather
- New provider `src/providers/qweather.ts` (index 3), registered in `createProvider`.
- Authentication via `X-QW-Api-Key` request header; since QWeather API hosts are per-user (`*.qweatherapi.com`), a new `api-hosts` setting (`a{ss}`, mirroring `api-keys`) stores the host.
- Fetches current / daily(7) / hourly(28) weather in parallel; converts QWeather's metric values to the internal imperial units; maps QWeather weather codes to the existing icon set; handles night-time variants (codes 150–153) and sunrise/sunset countdowns like the other providers.
- Non-2xx responses and business error codes (`code != "200"`) are surfaced as errors.

### New location provider: ip.sb
- Added as `MyLocationProvider.IpSb` (enum 5) in `myLocation.ts`; free, no API key needed.
- Fixed a pre-existing range guard in `config.getMyLocationProvider()` which silently reset `Disable`(3) and `Ipapi`(4) to ipinfo.

### City search auto-switch
- When QWeather is selected and its key/host are configured, location search uses QWeather GeoAPI city lookup; otherwise it falls back to Nominatim as before.

### Preferences UI
- New "API Host" entry row, shown/enabled only for providers that require a host.
- ip.sb added to the My Location provider list (online providers listed first).
- API key online validation now only runs for OpenWeatherMap, so saving a QWeather key no longer triggers a false OWM warning.

### Supporting changes
- `LibSoup.fetchJson` gained an optional `headers` parameter (backward compatible).
- `config.ts`: `getApiHosts()` / `onApiHostsChanged()` mirroring the existing api-keys accessors.
- gschema: `weather-provider` enum +`qweather`(3), `my-loc-provider` enum +`ip.sb`(5), new `api-hosts` key.

### Notes
- New UI strings are in English only; translations can follow the usual Crowdin workflow.
- Tested with a nested GNOME Shell (`./debug.sh`); `tsc` clean, schema compiles with `glib-compile-schemas --strict`.